### PR TITLE
Dev-gcp migrering relaterte fixes

### DIFF
--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -23,9 +23,9 @@ jobs:
         run: |
           cat > .env <<EOF
           NODE_ENV=production
-          APP_ORIGIN=https://person.dev.nav.no
+          APP_ORIGIN=https://www.dev.nav.no
           APP_BASE_PATH=/sok
-          DECORATOR_URL=https://dekoratoren.dev.nav.no
+          DECORATOR_URL=https://www.dev.nav.no/dekoratoren
           XP_ORIGIN=https://www.dev.nav.no
           EOF
       - uses: actions/cache@v2
@@ -46,7 +46,7 @@ jobs:
           cat > .nais/vars.yaml <<EOF
           namespace: personbruker
           ingresses:
-            - https://person.dev.nav.no/sok
+            - https://www.dev.nav.no/sok
           image: $IMAGE_REGISTRY/$IMAGE_NAME
           version: $IMAGE_VERSION
           EOF

--- a/.github/workflows/deploy.dev2.yml
+++ b/.github/workflows/deploy.dev2.yml
@@ -1,4 +1,4 @@
-name: Deploy-to-q6
+name: Deploy-to-dev2
 on:
   workflow_dispatch
 
@@ -23,9 +23,9 @@ jobs:
         run: |
           cat > .env <<EOF
           NODE_ENV=production
-          APP_ORIGIN=https://www-q6.nav.no
+          APP_ORIGIN=https://www-2.dev.nav.no
           APP_BASE_PATH=/sok
-          DECORATOR_URL=https://www-q6.nav.no/dekoratoren
+          DECORATOR_URL=https://www.dev.nav.no/dekoratoren
           XP_ORIGIN=https://www-q6.nav.no
           EOF
       - uses: actions/cache@v2
@@ -44,15 +44,15 @@ jobs:
       - name: Generate nais variables
         run: |
           cat > .nais/vars.yaml <<EOF
-          namespace: q6
+          namespace: personbruker
           ingresses:
-            - https://www-q6.nav.no/sok
+            - https://www-2.dev.nav.no/sok
           image: $IMAGE_REGISTRY/$IMAGE_NAME
           version: $IMAGE_VERSION
           EOF
       - uses: nais/deploy/actions/deploy@master
         env:
-          CLUSTER: dev-sbs
+          CLUSTER: dev-gcp
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           RESOURCE: .nais/config.yaml
           VARS: .nais/vars.yaml


### PR DESCRIPTION
- Bytter dev-gcp ingress til www.dev.nav.no/sok
- Migrerer "q6" til www-2.dev på dev-gcp (fortsatt koblet til q6 enonic)