### PR TITLE
Tar vekk logging av søkeord og destinasjon til Amplitude

### DIFF
--- a/src/components/SearchPage.tsx
+++ b/src/components/SearchPage.tsx
@@ -43,7 +43,7 @@ const SearchPage = () => {
         }
 
         setIsAwaitingResults(false);
-        logSearchQuery(params.ord);
+        logSearchQuery();
     };
 
     const { s, daterange, f, uf } = params;
@@ -59,7 +59,7 @@ const SearchPage = () => {
         enableClientsideFetch.current = true;
         logPageview();
         if (searchTerm) {
-            logSearchQuery(searchTerm);
+            logSearchQuery();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/components/results/search-hit/SearchHit.tsx
+++ b/src/components/results/search-hit/SearchHit.tsx
@@ -19,10 +19,9 @@ const parseHighlight = (highlight: string) => {
 type Props = {
     hit: SearchHitProps;
     hitIndex: number;
-    searchTerm: string;
 };
 
-export const SearchHit = ({ hit, hitIndex, searchTerm }: Props) => {
+export const SearchHit = ({ hit, hitIndex }: Props) => {
     const { displayName, href, highlight, officeInformation, audience } = hit;
 
     if (!displayName || !href) {
@@ -33,7 +32,7 @@ export const SearchHit = ({ hit, hitIndex, searchTerm }: Props) => {
         <LinkPanel
             href={href}
             className={style.searchHit}
-            onClick={() => logResultClick(href, searchTerm, hitIndex + 1)}
+            onClick={() => logResultClick(hitIndex + 1)}
         >
             <LinkPanel.Title>{displayName}</LinkPanel.Title>
             <div className={style.content}>

--- a/src/components/results/search-results-list/SearchResultsList.tsx
+++ b/src/components/results/search-results-list/SearchResultsList.tsx
@@ -55,7 +55,6 @@ export const SearchResultsList = ({ result }: Props) => {
                         <SearchHit
                             hit={hitProps}
                             hitIndex={index}
-                            searchTerm={result.word}
                             key={key}
                         />
                     );

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -14,21 +14,19 @@ const logAmplitudeEvent = (
 
 export const logPageview = () => logAmplitudeEvent('sidevisning');
 
-export const logSearchQuery = (searchTerm: string) =>
+export const logSearchQuery = () =>
     logAmplitudeEvent('søk', {
         destinasjon: Config.URLS.xpSearchService,
-        sokeord: searchTerm?.toLowerCase(),
+        sokeord: '[redacted]',
         komponent: 'søkeside',
     });
 
 export const logResultClick = (
-    href: string,
-    searchTerm?: string,
     hitIndex?: number
 ) =>
     logAmplitudeEvent('resultat-klikk', {
-        destinasjon: href,
-        sokeord: searchTerm?.toLowerCase(),
+        destinasjon: '[redacted]',
+        sokeord: '[redacted]',
         treffnr: hitIndex,
     });
 


### PR DESCRIPTION
Pålegg fra ResearchOps, fordi Amplitude ikke kan garantere lagring kun i EU.

## Testing
Har testet lokalt
