### PR TITLE
Ekstern ingress for dev med enkel tilgangskontroll

### DIFF
--- a/.nais/vars-dev1.yml
+++ b/.nais/vars-dev1.yml
@@ -4,6 +4,7 @@ dekoratorenAppName: nav-dekoratoren
 xpHost: www.dev.nav.no
 ingresses:
   - https://www.intern.dev.nav.no/sok($|\/.+)
+  - https://www.ekstern.dev.nav.no/sok($|\/.+)
 replicas:
   min: 1
   max: 2

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server';
+
+export const middleware = (req: NextRequest) => {
+    console.log(
+        `${req.headers.get('x-forwarded-for')} - ${req.headers.get(
+            'x-real-ip'
+        )} - ${req.ip}`
+    );
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,28 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export const middleware = (req: NextRequest) => {
-    console.log(
-        `${req.headers.get('x-forwarded-for')} - ${req.headers.get(
-            'x-real-ip'
-        )} - ${req.ip}`
-    );
-};
+const LOGIN_COOKIE = 'dev-login';
+
+// 155.55.* is NAVs public IP range. Also includes the private IP range used by our
+// internal network (10.*), and localhost. Takes the IPv6 prefix ::ffff: into account.
+const isNavIp = (ip: string | null) =>
+    ip && /^(::ffff:)?(155\.55\.|10\.|127\.)/.test(ip);
+
+// Applies certain restrictions for the app in dev environments. This is not intended
+// as a security measure, but rather to ensure (to some degree) that the public does
+// not accidentally end up in our (possibly confusing!) dev environments
+export const middleware =
+    process.env.ENV === 'dev1' || process.env.ENV === 'dev2'
+        ? (req: NextRequest) => {
+              const ip =
+                  req.ip ||
+                  req.headers.get('x-real-ip') ||
+                  req.headers.get('x-forwarded-for');
+
+              if (!(isNavIp(ip) || req.cookies.get(LOGIN_COOKIE))) {
+                  console.log(`Non-authorized client ip: ${ip}`);
+                  return new NextResponse('Ingen tilgang', { status: 401 });
+              }
+
+              return NextResponse.next();
+          }
+        : () => NextResponse.next();


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter opp tilsvarende som i XP-frontend'en for å blokkere tilgang fra eksterne IP'er. Ikke ment som sikkerhetstiltak, kun for å hindre at publikum roter seg inn i dev ved et uhell.