### PR TITLE
Bump dependencies 061123

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,30 +8,30 @@
             "name": "navno-search-frontend",
             "version": "1.0.16-prod",
             "dependencies": {
-                "@navikt/ds-css": "5.6.4",
+                "@navikt/ds-css": "5.9.2",
                 "@navikt/ds-icons": "3.4.3",
-                "@navikt/ds-react": "5.6.4",
-                "@navikt/ds-tokens": "5.6.4",
+                "@navikt/ds-react": "5.9.2",
+                "@navikt/ds-tokens": "5.9.2",
                 "@navikt/nav-dekoratoren-moduler": "2.1.3",
                 "dayjs": "1.11.10",
-                "html-react-parser": "4.2.2",
+                "html-react-parser": "5.0.6",
                 "js-cookie": "3.0.5",
-                "next": "13.5.4",
+                "next": "14.0.1",
                 "react": "18.2.0",
                 "react-dom": "18.2.0"
             },
             "devDependencies": {
-                "@types/js-cookie": "3.0.4",
-                "@types/node": "20.8.4",
-                "@types/react": "18.2.27",
-                "@types/react-dom": "18.2.12",
-                "eslint": "8.51.0",
-                "eslint-config-next": "13.5.4",
-                "eslint-plugin-css-modules": "2.11.4",
+                "@types/js-cookie": "3.0.5",
+                "@types/node": "20.8.10",
+                "@types/react": "18.2.36",
+                "@types/react-dom": "18.2.14",
+                "eslint": "8.53.0",
+                "eslint-config-next": "14.0.1",
+                "eslint-plugin-css-modules": "2.12.0",
                 "prettier": "3.0.3",
-                "sass": "1.69.1",
-                "typescript": "5.1.6",
-                "typescript-plugin-css-modules": "5.0.1"
+                "sass": "1.69.5",
+                "typescript": "5.2.2",
+                "typescript-plugin-css-modules": "5.0.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -85,9 +85,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
+            "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -108,9 +108,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
+            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -165,12 +165,12 @@
             "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.11",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-            "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
+                "@humanwhocodes/object-schema": "^2.0.1",
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.5"
             },
@@ -192,21 +192,21 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/5.6.4/e19deb88ecdc0324aaaba732fd7c2c1b448ab514",
-            "integrity": "sha512-O4BjhWaxORzpU/Y3AMSylSnPU0IC5rYZUi5N580h7HeEcEYXL+cBCaWqvzkQdK/NIuW6GMMpEABayw1xlUszYA==",
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/5.9.2/482bb83a2bc6b4e954700e278c28614c108117e3",
+            "integrity": "sha512-5XQI4wzZAlB6CoHDXZrjUqMx+7iUiOPoqFY3H9kT/NwfCdmUSPUFfmiPZHzpV7OzS4S61Joo1GhZ31ZZSIuz3Q==",
             "license": "MIT"
         },
         "node_modules/@navikt/ds-css": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/5.6.4/1a6fdb2ff4d0ea17a5775a0b532f06f83acd2fc4",
-            "integrity": "sha512-2nqwCxzyp59yLA51xnTKTyu1vyDj96P10kxfOo0jIMiNoM430fSx6ayqdd1x60H7HYlzj8wDtvB/tcPnGBHehg==",
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/5.9.2/1ec33efe65cd9a20d1a5e9e5a119702626c568d7",
+            "integrity": "sha512-uzXl4qgzJ934XGRG29rU3Te6jJ5pEiQEsgqOMKKuPMV8RBB2NP1x125bocvDfwEx5CVvr3WzCvxFnlYfFStDVw==",
             "license": "MIT"
         },
         "node_modules/@navikt/ds-icons": {
@@ -220,14 +220,14 @@
             }
         },
         "node_modules/@navikt/ds-react": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/5.6.4/feb661e7668d7fe7af94685553735b29b92981fe",
-            "integrity": "sha512-R1PKdWpD2JN7pb7vES5lKgiBYgYJsi41g3OozsDdHUxuNQovXkhbTUQGVKNSWLrYwLOYcIbXf5ZqsfabtSLJyw==",
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/5.9.2/0a0bf183f7cfd7f1932694e3d1829227ce6e6f33",
+            "integrity": "sha512-ElZvGW/dAylj9PHoOwdABuJVA1Pgx7+Rh4UR9auWQJTs97jklSJ5w78qC3W9SJAi5rVy+I5raFHGY3mW/m/lwA==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
-                "@navikt/aksel-icons": "^5.6.4",
-                "@navikt/ds-tokens": "^5.6.4",
+                "@navikt/aksel-icons": "^5.9.2",
+                "@navikt/ds-tokens": "^5.9.2",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -240,9 +240,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/5.6.4/6c068cc57bd75e82926762432596a7da61892ab9",
-            "integrity": "sha512-yyLcVESKCAk6bUuL78uON2rbH35WDdWBNvUagf1pvTw9zeptgFuTho8IxpcpQHuY2NZLDZsn5RajloDg3C9GZw==",
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/5.9.2/f410260891058d4d3ec19f1c2c175274c3b637ca",
+            "integrity": "sha512-MzDHuUE0adzgDfat/CStgHSBtvbIxCpY82VNlJ6qLoC7T/rlDCKAaktjLTD1JHPizlawOqJgQp3tOG2vHJKE6A==",
             "license": "MIT"
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
@@ -305,14 +305,14 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
-            "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.1.tgz",
+            "integrity": "sha512-Ms8ZswqY65/YfcjrlcIwMPD7Rg/dVjdLapMcSHG26W6O67EJDF435ShW4H4LXi1xKO1oRc97tLXUpx8jpLe86A=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.4.tgz",
-            "integrity": "sha512-vI94U+D7RNgX6XypSyjeFrOzxGlZyxOplU0dVE5norIfZGn/LDjJYPHdvdsR5vN1eRtl6PDAsOHmycFEOljK5A==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.1.tgz",
+            "integrity": "sha512-bLjJMwXdzvhnQOnxvHoTTUh/+PYk6FF/DCgHi4BXwXCINer+o1ZYfL9aVeezj/oI7wqGJOqwGIXrlBvPbAId3w==",
             "dev": true,
             "dependencies": {
                 "glob": "7.1.7"
@@ -339,9 +339,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
-            "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
+            "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
             "cpu": [
                 "arm64"
             ],
@@ -354,9 +354,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
-            "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
+            "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
             "cpu": [
                 "x64"
             ],
@@ -369,9 +369,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
-            "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
+            "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
             "cpu": [
                 "arm64"
             ],
@@ -384,9 +384,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
-            "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
+            "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
             "cpu": [
                 "arm64"
             ],
@@ -399,9 +399,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
-            "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
+            "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
             "cpu": [
                 "x64"
             ],
@@ -414,9 +414,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
-            "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
+            "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
             "cpu": [
                 "x64"
             ],
@@ -429,9 +429,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
-            "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
+            "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
             "cpu": [
                 "arm64"
             ],
@@ -444,9 +444,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
-            "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
+            "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
             "cpu": [
                 "ia32"
             ],
@@ -459,9 +459,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
-            "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
+            "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
             "cpu": [
                 "x64"
             ],
@@ -780,9 +780,9 @@
             }
         },
         "node_modules/@types/js-cookie": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.4.tgz",
-            "integrity": "sha512-vMMnFF+H5KYqdd/myCzq6wLDlPpteJK+jGFgBus3Da7lw+YsDmx2C8feGTzY2M3Fo823yON+HC2CL240j4OV+w==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-dtLshqoiGRDHbHueIT9sjkd2F4tW1qPSX2xKAQK8p1e6pM+Z913GM1shv7dOqqasEMYbC5zEaClJomQe8OtQLA==",
             "dev": true
         },
         "node_modules/@types/json5": {
@@ -792,12 +792,12 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.8.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
-            "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+            "version": "20.8.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
             "dev": true,
             "dependencies": {
-                "undici-types": "~5.25.1"
+                "undici-types": "~5.26.4"
             }
         },
         "node_modules/@types/postcss-modules-local-by-default": {
@@ -824,9 +824,9 @@
             "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
         },
         "node_modules/@types/react": {
-            "version": "18.2.27",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.27.tgz",
-            "integrity": "sha512-Wfv7B7FZiR2r3MIqbAlXoY1+tXm4bOqfz4oRr+nyXdBqapDBZ0l/IGcSlAfvxIHEEJjkPU0MYAc/BlFPOcrgLw==",
+            "version": "18.2.36",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.36.tgz",
+            "integrity": "sha512-o9XFsHYLLZ4+sb9CWUYwHqFVoG61SesydF353vFMMsQziiyRu8np4n2OYMUSDZ8XuImxDr9c5tR7gidlH29Vnw==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -834,9 +834,9 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.2.12",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.12.tgz",
-            "integrity": "sha512-QWZuiA/7J/hPIGocXreCRbx7wyoeet9ooxfbSA+zbIWqyQEE7GMtRn4A37BdYyksnN+/NDnWgfxZH9UVGDw1hg==",
+            "version": "18.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
+            "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
@@ -1011,6 +1011,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -1988,18 +1994,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
+            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.51.0",
-                "@humanwhocodes/config-array": "^0.11.11",
+                "@eslint/eslintrc": "^2.1.3",
+                "@eslint/js": "8.53.0",
+                "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -2042,12 +2049,12 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.4.tgz",
-            "integrity": "sha512-FzQGIj4UEszRX7fcRSJK6L1LrDiVZvDFW320VVntVKh3BSU8Fb9kpaoxQx0cdFgf3MQXdeSbrCXJ/5Z/NndDkQ==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.0.1.tgz",
+            "integrity": "sha512-QfIFK2WD39H4WOespjgf6PLv9Bpsd7KGGelCtmq4l67nGvnlsGpuvj0hIT+aIy6p5gKH+lAChYILsyDlxP52yg==",
             "dev": true,
             "dependencies": {
-                "@next/eslint-plugin-next": "13.5.4",
+                "@next/eslint-plugin-next": "14.0.1",
                 "@rushstack/eslint-patch": "^1.3.3",
                 "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
@@ -2188,12 +2195,12 @@
             }
         },
         "node_modules/eslint-plugin-css-modules": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.11.4.tgz",
-            "integrity": "sha512-pZYaW2hDUSz8Exb3BXVeu075MV23roLmubPb4EVeKvNdksVZ3gyzfuBCNazdxmPJkVspu3A6cwjH08y+GcoXkg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.12.0.tgz",
+            "integrity": "sha512-ruFBdad69ABrbCDCh5mXj7UzNmrvytfzPACjyvZWIAjFZAG8BXpYSbqmE8gU5wF+pIzV3jU2CWhLvfekXT/IgQ==",
             "dev": true,
             "dependencies": {
-                "gonzales-pe": "^4.0.3",
+                "gonzales-pe": "^4.3.0",
                 "lodash": "^4.17.2"
             },
             "engines": {
@@ -2844,9 +2851,9 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "node_modules/globals": {
-            "version": "13.21.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+            "version": "13.23.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+            "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -3016,9 +3023,9 @@
             }
         },
         "node_modules/html-dom-parser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
-            "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.4.tgz",
+            "integrity": "sha512-azy8THLKd4Ar0OVJpEgX+MSjYvKdNDWlGiRBIlovMqEQYMAnLLXBhhiSwjylDD3RDdcCYT8Utg6uoRDeLHUyHg==",
             "dependencies": {
                 "domhandler": "5.0.3",
                 "htmlparser2": "9.0.0"
@@ -3037,33 +3044,43 @@
             }
         },
         "node_modules/html-react-parser": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-4.2.2.tgz",
-            "integrity": "sha512-lh0wEGISnFZEAmvQqK4xc0duFMUh/m9YYyAhFursWxdtNv+hCZge0kj1y4wep6qPB5Zm33L+2/P6TcGWAJJbjA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.0.6.tgz",
+            "integrity": "sha512-aPSzFhO2bK/L/mYQbMwFz+1QG8nhxozbwENt/52HTApasrBvDX87MFD5uSQIjq7Io0bnKzH4uh7PM42zZ4ag9A==",
             "dependencies": {
                 "domhandler": "5.0.3",
-                "html-dom-parser": "4.0.0",
-                "react-property": "2.0.0",
-                "style-to-js": "1.1.4"
+                "html-dom-parser": "5.0.4",
+                "react-property": "2.0.2",
+                "style-to-js": "1.1.9"
             },
             "peerDependencies": {
                 "react": "0.14 || 15 || 16 || 17 || 18"
             }
         },
+        "node_modules/html-react-parser/node_modules/inline-style-parser": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
+            "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
+        },
+        "node_modules/html-react-parser/node_modules/react-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+            "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+        },
         "node_modules/html-react-parser/node_modules/style-to-js": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.4.tgz",
-            "integrity": "sha512-zEeU3vy9xL/hdLBFmzqjhm+2vJ1Y35V0ctDeB2sddsvN1856OdMZUCOOfKUn3nOjjEKr6uLhOnY4CrX6gLDRrA==",
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.9.tgz",
+            "integrity": "sha512-6bkwhOlPOx+wKiHVlPTHjUqM4zDKv9pyccehB8zetZL0hhQ7MVp7UEWUsohjiMdxwhSsEdjMrEve+8qzUVmY4w==",
             "dependencies": {
-                "style-to-object": "0.4.2"
+                "style-to-object": "1.0.4"
             }
         },
         "node_modules/html-react-parser/node_modules/style-to-object": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
-            "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.4.tgz",
+            "integrity": "sha512-KyNO6mfijxSnypdvEjeXlhvbGPSh0l1zBJp80n+ncBQvrEbSwBHwZCpo0xz6Q4AKSPfXowWwypCBAUAdfz3rFQ==",
             "dependencies": {
-                "inline-style-parser": "0.1.1"
+                "inline-style-parser": "0.2.2"
             }
         },
         "node_modules/htmlparser2": {
@@ -3997,11 +4014,11 @@
             }
         },
         "node_modules/next": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
-            "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.0.1.tgz",
+            "integrity": "sha512-s4YaLpE4b0gmb3ggtmpmV+wt+lPRuGtANzojMQ2+gmBpgX9w5fTbjsy6dXByBuENsdCX5pukZH/GxdFgO62+pA==",
             "dependencies": {
-                "@next/env": "13.5.4",
+                "@next/env": "14.0.1",
                 "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
@@ -4013,18 +4030,18 @@
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": ">=16.14.0"
+                "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "13.5.4",
-                "@next/swc-darwin-x64": "13.5.4",
-                "@next/swc-linux-arm64-gnu": "13.5.4",
-                "@next/swc-linux-arm64-musl": "13.5.4",
-                "@next/swc-linux-x64-gnu": "13.5.4",
-                "@next/swc-linux-x64-musl": "13.5.4",
-                "@next/swc-win32-arm64-msvc": "13.5.4",
-                "@next/swc-win32-ia32-msvc": "13.5.4",
-                "@next/swc-win32-x64-msvc": "13.5.4"
+                "@next/swc-darwin-arm64": "14.0.1",
+                "@next/swc-darwin-x64": "14.0.1",
+                "@next/swc-linux-arm64-gnu": "14.0.1",
+                "@next/swc-linux-arm64-musl": "14.0.1",
+                "@next/swc-linux-x64-gnu": "14.0.1",
+                "@next/swc-linux-x64-musl": "14.0.1",
+                "@next/swc-win32-arm64-msvc": "14.0.1",
+                "@next/swc-win32-ia32-msvc": "14.0.1",
+                "@next/swc-win32-x64-msvc": "14.0.1"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -4767,9 +4784,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sass": {
-            "version": "1.69.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.1.tgz",
-            "integrity": "sha512-nc969GvTVz38oqKgYYVHM/Iq7Yl33IILy5uqaH2CWSiSUmRCvw+UR7tA3845Sp4BD5ykCUimvrT3k1EjTwpVUA==",
+            "version": "1.69.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
             "devOptional": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -5298,9 +5315,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5311,9 +5328,9 @@
             }
         },
         "node_modules/typescript-plugin-css-modules": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.0.1.tgz",
-            "integrity": "sha512-hKXObfwfjx2/myRq4JeQ8D3xIWYTFqusi0hS/Aka7RFX1xQEoEkdOGDWyXNb8LmObawsUzbI30gQnZvqYXCrkA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.0.2.tgz",
+            "integrity": "sha512-ej/Og4Y8mF+43P14P9Ik1MGqNXcXBVgO1TltkESegdnZsaaRXnaJ5CoJmTPRkg25ysQlOV6P94wNhI4VxIzlkw==",
             "dev": true,
             "dependencies": {
                 "@types/postcss-modules-local-by-default": "^4.0.0",
@@ -5408,9 +5425,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.25.3",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-            "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
         "node_modules/universalify": {
@@ -5726,9 +5743,9 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
+            "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -5743,9 +5760,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
+            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
             "dev": true
         },
         "@floating-ui/core": {
@@ -5789,12 +5806,12 @@
             "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
         "@humanwhocodes/config-array": {
-            "version": "0.11.11",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-            "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
+                "@humanwhocodes/object-schema": "^2.0.1",
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.5"
             }
@@ -5806,20 +5823,20 @@
             "dev": true
         },
         "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
         "@navikt/aksel-icons": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/5.6.4/e19deb88ecdc0324aaaba732fd7c2c1b448ab514",
-            "integrity": "sha512-O4BjhWaxORzpU/Y3AMSylSnPU0IC5rYZUi5N580h7HeEcEYXL+cBCaWqvzkQdK/NIuW6GMMpEABayw1xlUszYA=="
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/5.9.2/482bb83a2bc6b4e954700e278c28614c108117e3",
+            "integrity": "sha512-5XQI4wzZAlB6CoHDXZrjUqMx+7iUiOPoqFY3H9kT/NwfCdmUSPUFfmiPZHzpV7OzS4S61Joo1GhZ31ZZSIuz3Q=="
         },
         "@navikt/ds-css": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/5.6.4/1a6fdb2ff4d0ea17a5775a0b532f06f83acd2fc4",
-            "integrity": "sha512-2nqwCxzyp59yLA51xnTKTyu1vyDj96P10kxfOo0jIMiNoM430fSx6ayqdd1x60H7HYlzj8wDtvB/tcPnGBHehg=="
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/5.9.2/1ec33efe65cd9a20d1a5e9e5a119702626c568d7",
+            "integrity": "sha512-uzXl4qgzJ934XGRG29rU3Te6jJ5pEiQEsgqOMKKuPMV8RBB2NP1x125bocvDfwEx5CVvr3WzCvxFnlYfFStDVw=="
         },
         "@navikt/ds-icons": {
             "version": "3.4.3",
@@ -5828,13 +5845,13 @@
             "requires": {}
         },
         "@navikt/ds-react": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/5.6.4/feb661e7668d7fe7af94685553735b29b92981fe",
-            "integrity": "sha512-R1PKdWpD2JN7pb7vES5lKgiBYgYJsi41g3OozsDdHUxuNQovXkhbTUQGVKNSWLrYwLOYcIbXf5ZqsfabtSLJyw==",
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/5.9.2/0a0bf183f7cfd7f1932694e3d1829227ce6e6f33",
+            "integrity": "sha512-ElZvGW/dAylj9PHoOwdABuJVA1Pgx7+Rh4UR9auWQJTs97jklSJ5w78qC3W9SJAi5rVy+I5raFHGY3mW/m/lwA==",
             "requires": {
                 "@floating-ui/react": "0.25.4",
-                "@navikt/aksel-icons": "^5.6.4",
-                "@navikt/ds-tokens": "^5.6.4",
+                "@navikt/aksel-icons": "^5.9.2",
+                "@navikt/ds-tokens": "^5.9.2",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -5843,9 +5860,9 @@
             }
         },
         "@navikt/ds-tokens": {
-            "version": "5.6.4",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/5.6.4/6c068cc57bd75e82926762432596a7da61892ab9",
-            "integrity": "sha512-yyLcVESKCAk6bUuL78uON2rbH35WDdWBNvUagf1pvTw9zeptgFuTho8IxpcpQHuY2NZLDZsn5RajloDg3C9GZw=="
+            "version": "5.9.2",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/5.9.2/f410260891058d4d3ec19f1c2c175274c3b637ca",
+            "integrity": "sha512-MzDHuUE0adzgDfat/CStgHSBtvbIxCpY82VNlJ6qLoC7T/rlDCKAaktjLTD1JHPizlawOqJgQp3tOG2vHJKE6A=="
         },
         "@navikt/nav-dekoratoren-moduler": {
             "version": "2.1.3",
@@ -5891,14 +5908,14 @@
             }
         },
         "@next/env": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
-            "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.1.tgz",
+            "integrity": "sha512-Ms8ZswqY65/YfcjrlcIwMPD7Rg/dVjdLapMcSHG26W6O67EJDF435ShW4H4LXi1xKO1oRc97tLXUpx8jpLe86A=="
         },
         "@next/eslint-plugin-next": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.4.tgz",
-            "integrity": "sha512-vI94U+D7RNgX6XypSyjeFrOzxGlZyxOplU0dVE5norIfZGn/LDjJYPHdvdsR5vN1eRtl6PDAsOHmycFEOljK5A==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.1.tgz",
+            "integrity": "sha512-bLjJMwXdzvhnQOnxvHoTTUh/+PYk6FF/DCgHi4BXwXCINer+o1ZYfL9aVeezj/oI7wqGJOqwGIXrlBvPbAId3w==",
             "dev": true,
             "requires": {
                 "glob": "7.1.7"
@@ -5921,57 +5938,57 @@
             }
         },
         "@next/swc-darwin-arm64": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
-            "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.1.tgz",
+            "integrity": "sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
-            "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.1.tgz",
+            "integrity": "sha512-625Z7bb5AyIzswF9hvfZWa+HTwFZw+Jn3lOBNZB87lUS0iuCYDHqk3ujuHCkiyPtSC0xFBtYDLcrZ11mF/ap3w==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
-            "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.1.tgz",
+            "integrity": "sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
-            "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.1.tgz",
+            "integrity": "sha512-mVsGyMxTLWZXyD5sen6kGOTYVOO67lZjLApIj/JsTEEohDDt1im2nkspzfV5MvhfS7diDw6Rp/xvAQaWZTv1Ww==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
-            "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.1.tgz",
+            "integrity": "sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
-            "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.1.tgz",
+            "integrity": "sha512-ol1X1e24w4j4QwdeNjfX0f+Nza25n+ymY0T2frTyalVczUmzkVD7QGgPTZMHfR1aLrO69hBs0G3QBYaj22J5GQ==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
-            "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.1.tgz",
+            "integrity": "sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
-            "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.1.tgz",
+            "integrity": "sha512-oFpHphN4ygAgZUKjzga7SoH2VGbEJXZa/KL8bHCAwCjDWle6R1SpiGOdUdA8EJ9YsG1TYWpzY6FTbUA+iAJeww==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
-            "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.1.tgz",
+            "integrity": "sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==",
             "optional": true
         },
         "@nodelib/fs.scandir": {
@@ -6215,9 +6232,9 @@
             "peer": true
         },
         "@types/js-cookie": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.4.tgz",
-            "integrity": "sha512-vMMnFF+H5KYqdd/myCzq6wLDlPpteJK+jGFgBus3Da7lw+YsDmx2C8feGTzY2M3Fo823yON+HC2CL240j4OV+w==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-dtLshqoiGRDHbHueIT9sjkd2F4tW1qPSX2xKAQK8p1e6pM+Z913GM1shv7dOqqasEMYbC5zEaClJomQe8OtQLA==",
             "dev": true
         },
         "@types/json5": {
@@ -6227,12 +6244,12 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.8.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
-            "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+            "version": "20.8.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
             "dev": true,
             "requires": {
-                "undici-types": "~5.25.1"
+                "undici-types": "~5.26.4"
             }
         },
         "@types/postcss-modules-local-by-default": {
@@ -6259,9 +6276,9 @@
             "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
         },
         "@types/react": {
-            "version": "18.2.27",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.27.tgz",
-            "integrity": "sha512-Wfv7B7FZiR2r3MIqbAlXoY1+tXm4bOqfz4oRr+nyXdBqapDBZ0l/IGcSlAfvxIHEEJjkPU0MYAc/BlFPOcrgLw==",
+            "version": "18.2.36",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.36.tgz",
+            "integrity": "sha512-o9XFsHYLLZ4+sb9CWUYwHqFVoG61SesydF353vFMMsQziiyRu8np4n2OYMUSDZ8XuImxDr9c5tR7gidlH29Vnw==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -6269,9 +6286,9 @@
             }
         },
         "@types/react-dom": {
-            "version": "18.2.12",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.12.tgz",
-            "integrity": "sha512-QWZuiA/7J/hPIGocXreCRbx7wyoeet9ooxfbSA+zbIWqyQEE7GMtRn4A37BdYyksnN+/NDnWgfxZH9UVGDw1hg==",
+            "version": "18.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
+            "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
             "dev": true,
             "requires": {
                 "@types/react": "*"
@@ -6374,6 +6391,12 @@
                 "@typescript-eslint/types": "5.48.2",
                 "eslint-visitor-keys": "^3.3.0"
             }
+        },
+        "@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
         },
         "abab": {
             "version": "2.0.6",
@@ -7117,18 +7140,19 @@
             }
         },
         "eslint": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
+            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.51.0",
-                "@humanwhocodes/config-array": "^0.11.11",
+                "@eslint/eslintrc": "^2.1.3",
+                "@eslint/js": "8.53.0",
+                "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -7228,12 +7252,12 @@
             }
         },
         "eslint-config-next": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.4.tgz",
-            "integrity": "sha512-FzQGIj4UEszRX7fcRSJK6L1LrDiVZvDFW320VVntVKh3BSU8Fb9kpaoxQx0cdFgf3MQXdeSbrCXJ/5Z/NndDkQ==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.0.1.tgz",
+            "integrity": "sha512-QfIFK2WD39H4WOespjgf6PLv9Bpsd7KGGelCtmq4l67nGvnlsGpuvj0hIT+aIy6p5gKH+lAChYILsyDlxP52yg==",
             "dev": true,
             "requires": {
-                "@next/eslint-plugin-next": "13.5.4",
+                "@next/eslint-plugin-next": "14.0.1",
                 "@rushstack/eslint-patch": "^1.3.3",
                 "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
@@ -7333,12 +7357,12 @@
             }
         },
         "eslint-plugin-css-modules": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.11.4.tgz",
-            "integrity": "sha512-pZYaW2hDUSz8Exb3BXVeu075MV23roLmubPb4EVeKvNdksVZ3gyzfuBCNazdxmPJkVspu3A6cwjH08y+GcoXkg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.12.0.tgz",
+            "integrity": "sha512-ruFBdad69ABrbCDCh5mXj7UzNmrvytfzPACjyvZWIAjFZAG8BXpYSbqmE8gU5wF+pIzV3jU2CWhLvfekXT/IgQ==",
             "dev": true,
             "requires": {
-                "gonzales-pe": "^4.0.3",
+                "gonzales-pe": "^4.3.0",
                 "lodash": "^4.17.2"
             }
         },
@@ -7755,9 +7779,9 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "globals": {
-            "version": "13.21.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+            "version": "13.23.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+            "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -7873,9 +7897,9 @@
             }
         },
         "html-dom-parser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
-            "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.4.tgz",
+            "integrity": "sha512-azy8THLKd4Ar0OVJpEgX+MSjYvKdNDWlGiRBIlovMqEQYMAnLLXBhhiSwjylDD3RDdcCYT8Utg6uoRDeLHUyHg==",
             "requires": {
                 "domhandler": "5.0.3",
                 "htmlparser2": "9.0.0"
@@ -7891,30 +7915,40 @@
             }
         },
         "html-react-parser": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-4.2.2.tgz",
-            "integrity": "sha512-lh0wEGISnFZEAmvQqK4xc0duFMUh/m9YYyAhFursWxdtNv+hCZge0kj1y4wep6qPB5Zm33L+2/P6TcGWAJJbjA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.0.6.tgz",
+            "integrity": "sha512-aPSzFhO2bK/L/mYQbMwFz+1QG8nhxozbwENt/52HTApasrBvDX87MFD5uSQIjq7Io0bnKzH4uh7PM42zZ4ag9A==",
             "requires": {
                 "domhandler": "5.0.3",
-                "html-dom-parser": "4.0.0",
-                "react-property": "2.0.0",
-                "style-to-js": "1.1.4"
+                "html-dom-parser": "5.0.4",
+                "react-property": "2.0.2",
+                "style-to-js": "1.1.9"
             },
             "dependencies": {
+                "inline-style-parser": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
+                    "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
+                },
+                "react-property": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+                    "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+                },
                 "style-to-js": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.4.tgz",
-                    "integrity": "sha512-zEeU3vy9xL/hdLBFmzqjhm+2vJ1Y35V0ctDeB2sddsvN1856OdMZUCOOfKUn3nOjjEKr6uLhOnY4CrX6gLDRrA==",
+                    "version": "1.1.9",
+                    "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.9.tgz",
+                    "integrity": "sha512-6bkwhOlPOx+wKiHVlPTHjUqM4zDKv9pyccehB8zetZL0hhQ7MVp7UEWUsohjiMdxwhSsEdjMrEve+8qzUVmY4w==",
                     "requires": {
-                        "style-to-object": "0.4.2"
+                        "style-to-object": "1.0.4"
                     }
                 },
                 "style-to-object": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
-                    "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.4.tgz",
+                    "integrity": "sha512-KyNO6mfijxSnypdvEjeXlhvbGPSh0l1zBJp80n+ncBQvrEbSwBHwZCpo0xz6Q4AKSPfXowWwypCBAUAdfz3rFQ==",
                     "requires": {
-                        "inline-style-parser": "0.1.1"
+                        "inline-style-parser": "0.2.2"
                     }
                 }
             }
@@ -8592,20 +8626,20 @@
             }
         },
         "next": {
-            "version": "13.5.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
-            "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.0.1.tgz",
+            "integrity": "sha512-s4YaLpE4b0gmb3ggtmpmV+wt+lPRuGtANzojMQ2+gmBpgX9w5fTbjsy6dXByBuENsdCX5pukZH/GxdFgO62+pA==",
             "requires": {
-                "@next/env": "13.5.4",
-                "@next/swc-darwin-arm64": "13.5.4",
-                "@next/swc-darwin-x64": "13.5.4",
-                "@next/swc-linux-arm64-gnu": "13.5.4",
-                "@next/swc-linux-arm64-musl": "13.5.4",
-                "@next/swc-linux-x64-gnu": "13.5.4",
-                "@next/swc-linux-x64-musl": "13.5.4",
-                "@next/swc-win32-arm64-msvc": "13.5.4",
-                "@next/swc-win32-ia32-msvc": "13.5.4",
-                "@next/swc-win32-x64-msvc": "13.5.4",
+                "@next/env": "14.0.1",
+                "@next/swc-darwin-arm64": "14.0.1",
+                "@next/swc-darwin-x64": "14.0.1",
+                "@next/swc-linux-arm64-gnu": "14.0.1",
+                "@next/swc-linux-arm64-musl": "14.0.1",
+                "@next/swc-linux-x64-gnu": "14.0.1",
+                "@next/swc-linux-x64-musl": "14.0.1",
+                "@next/swc-win32-arm64-msvc": "14.0.1",
+                "@next/swc-win32-ia32-msvc": "14.0.1",
+                "@next/swc-win32-x64-msvc": "14.0.1",
                 "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
@@ -9113,9 +9147,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sass": {
-            "version": "1.69.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.1.tgz",
-            "integrity": "sha512-nc969GvTVz38oqKgYYVHM/Iq7Yl33IILy5uqaH2CWSiSUmRCvw+UR7tA3845Sp4BD5ykCUimvrT3k1EjTwpVUA==",
+            "version": "1.69.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
             "devOptional": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -9505,15 +9539,15 @@
             }
         },
         "typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true
         },
         "typescript-plugin-css-modules": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.0.1.tgz",
-            "integrity": "sha512-hKXObfwfjx2/myRq4JeQ8D3xIWYTFqusi0hS/Aka7RFX1xQEoEkdOGDWyXNb8LmObawsUzbI30gQnZvqYXCrkA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.0.2.tgz",
+            "integrity": "sha512-ej/Og4Y8mF+43P14P9Ik1MGqNXcXBVgO1TltkESegdnZsaaRXnaJ5CoJmTPRkg25ysQlOV6P94wNhI4VxIzlkw==",
             "dev": true,
             "requires": {
                 "@types/postcss-modules-local-by-default": "^4.0.0",
@@ -9576,9 +9610,9 @@
             }
         },
         "undici-types": {
-            "version": "5.25.3",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-            "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
         "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,12 +25,12 @@
                 "@types/node": "20.8.10",
                 "@types/react": "18.2.36",
                 "@types/react-dom": "18.2.14",
-                "eslint": "8.53.0",
+                "eslint": "8.51.0",
                 "eslint-config-next": "14.0.1",
                 "eslint-plugin-css-modules": "2.12.0",
                 "prettier": "3.0.3",
                 "sass": "1.69.5",
-                "typescript": "5.2.2",
+                "typescript": "5.1.6",
                 "typescript-plugin-css-modules": "5.0.2"
             }
         },
@@ -108,9 +108,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
+            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1011,12 +1011,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
-        },
-        "node_modules/@ungap/structured-clone": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-            "dev": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -1994,19 +1988,18 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
+            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.3",
-                "@eslint/js": "8.53.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/eslintrc": "^2.1.2",
+                "@eslint/js": "8.51.0",
+                "@humanwhocodes/config-array": "^0.11.11",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -5315,9 +5308,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5760,9 +5753,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
+            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
             "dev": true
         },
         "@floating-ui/core": {
@@ -6391,12 +6384,6 @@
                 "@typescript-eslint/types": "5.48.2",
                 "eslint-visitor-keys": "^3.3.0"
             }
-        },
-        "@ungap/structured-clone": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-            "dev": true
         },
         "abab": {
             "version": "2.0.6",
@@ -7140,19 +7127,18 @@
             }
         },
         "eslint": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
+            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.3",
-                "@eslint/js": "8.53.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/eslintrc": "^2.1.2",
+                "@eslint/js": "8.51.0",
+                "@humanwhocodes/config-array": "^0.11.11",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -9539,9 +9525,9 @@
             }
         },
         "typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true
         },
         "typescript-plugin-css-modules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,16 +21,16 @@
                 "react-dom": "18.2.0"
             },
             "devDependencies": {
-                "@types/js-cookie": "3.0.5",
-                "@types/node": "20.8.10",
+                "@types/js-cookie": "3.0.6",
+                "@types/node": "20.5.6",
                 "@types/react": "18.2.36",
                 "@types/react-dom": "18.2.14",
-                "eslint": "8.51.0",
+                "eslint": "8.52.0",
                 "eslint-config-next": "14.0.1",
                 "eslint-plugin-css-modules": "2.12.0",
                 "prettier": "3.0.3",
                 "sass": "1.69.5",
-                "typescript": "5.1.6",
+                "typescript": "5.2.2",
                 "typescript-plugin-css-modules": "5.0.2"
             }
         },
@@ -108,9 +108,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+            "version": "8.52.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
+            "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -780,9 +780,9 @@
             }
         },
         "node_modules/@types/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-dtLshqoiGRDHbHueIT9sjkd2F4tW1qPSX2xKAQK8p1e6pM+Z913GM1shv7dOqqasEMYbC5zEaClJomQe8OtQLA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+            "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
             "dev": true
         },
         "node_modules/@types/json5": {
@@ -792,13 +792,10 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.8.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
-            "dev": true,
-            "dependencies": {
-                "undici-types": "~5.26.4"
-            }
+            "version": "20.5.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
+            "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==",
+            "dev": true
         },
         "node_modules/@types/postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -848,25 +845,26 @@
             "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.2.tgz",
-            "integrity": "sha512-38zMsKsG2sIuM5Oi/olurGwYJXzmtdsHhn5mI/pQogP+BjYVkK5iRazCQ8RGS0V+YLk282uWElN70zAAUmaYHw==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
+            "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.48.2",
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/typescript-estree": "5.48.2",
+                "@typescript-eslint/scope-manager": "6.10.0",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/typescript-estree": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -874,34 +872,17 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-            "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+            "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/visitor-keys": "5.48.2"
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -909,12 +890,12 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-            "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+            "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
             "dev": true,
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -922,21 +903,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-            "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+            "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/visitor-keys": "5.48.2",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -948,27 +929,10 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -980,37 +944,28 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-            "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+            "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.48.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "@typescript-eslint/types": "6.10.0",
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -1579,9 +1534,9 @@
             "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
         },
         "node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -1988,18 +1943,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+            "version": "8.52.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
+            "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.51.0",
-                "@humanwhocodes/config-array": "^0.11.11",
+                "@eslint/js": "8.52.0",
+                "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -2111,23 +2067,6 @@
             "peerDependencies": {
                 "eslint": "*",
                 "eslint-plugin-import": "*"
-            }
-        },
-        "node_modules/eslint-import-resolver-typescript/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/eslint-import-resolver-typescript/node_modules/globby": {
@@ -5200,6 +5139,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ts-api-utils": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.13.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -5211,12 +5162,6 @@
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
             }
-        },
-        "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -5308,9 +5253,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5416,12 +5361,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
         },
         "node_modules/universalify": {
             "version": "0.2.0",
@@ -5753,9 +5692,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+            "version": "8.52.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
+            "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
             "dev": true
         },
         "@floating-ui/core": {
@@ -6225,9 +6164,9 @@
             "peer": true
         },
         "@types/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-dtLshqoiGRDHbHueIT9sjkd2F4tW1qPSX2xKAQK8p1e6pM+Z913GM1shv7dOqqasEMYbC5zEaClJomQe8OtQLA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+            "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
             "dev": true
         },
         "@types/json5": {
@@ -6237,13 +6176,10 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.8.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
-            "dev": true,
-            "requires": {
-                "undici-types": "~5.26.4"
-            }
+            "version": "20.5.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
+            "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==",
+            "dev": true
         },
         "@types/postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -6293,97 +6229,75 @@
             "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
         },
         "@typescript-eslint/parser": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.2.tgz",
-            "integrity": "sha512-38zMsKsG2sIuM5Oi/olurGwYJXzmtdsHhn5mI/pQogP+BjYVkK5iRazCQ8RGS0V+YLk282uWElN70zAAUmaYHw==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
+            "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.48.2",
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/typescript-estree": "5.48.2",
+                "@typescript-eslint/scope-manager": "6.10.0",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/typescript-estree": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                }
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.2.tgz",
-            "integrity": "sha512-zEUFfonQid5KRDKoI3O+uP1GnrFd4tIHlvs+sTJXiWuypUWMuDaottkJuR612wQfOkjYbsaskSIURV9xo4f+Fw==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+            "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/visitor-keys": "5.48.2"
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.2.tgz",
-            "integrity": "sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+            "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.2.tgz",
-            "integrity": "sha512-bibvD3z6ilnoVxUBFEgkO0k0aFvUc4Cttt0dAreEr+nrAHhWzkO83PEVVuieK3DqcgL6VAK5dkzK8XUVja5Zcg==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+            "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.48.2",
-                "@typescript-eslint/visitor-keys": "5.48.2",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
                 "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
-                    }
-                },
-                "tsutils": {
-                    "version": "3.21.0",
-                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-                    "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-                    "dev": true,
-                    "requires": {
-                        "tslib": "^1.8.1"
                     }
                 }
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.48.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.2.tgz",
-            "integrity": "sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+            "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.48.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "@typescript-eslint/types": "6.10.0",
+                "eslint-visitor-keys": "^3.4.1"
             }
+        },
+        "@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
         },
         "abab": {
             "version": "2.0.6",
@@ -6814,9 +6728,9 @@
             "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
         },
         "debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
             }
@@ -7127,18 +7041,19 @@
             }
         },
         "eslint": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+            "version": "8.52.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
+            "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.51.0",
-                "@humanwhocodes/config-array": "^0.11.11",
+                "@eslint/js": "8.52.0",
+                "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -7292,15 +7207,6 @@
                 "synckit": "^0.8.5"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
                 "globby": {
                     "version": "13.1.4",
                     "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
@@ -9444,6 +9350,13 @@
                 "punycode": "^2.1.1"
             }
         },
+        "ts-api-utils": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "dev": true,
+            "requires": {}
+        },
         "tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -9455,12 +9368,6 @@
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
             }
-        },
-        "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
         },
         "type-check": {
             "version": "0.4.0",
@@ -9525,9 +9432,9 @@
             }
         },
         "typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true
         },
         "typescript-plugin-css-modules": {
@@ -9594,12 +9501,6 @@
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
             }
-        },
-        "undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
         },
         "universalify": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,30 +10,30 @@
         "lint": "eslint src/"
     },
     "dependencies": {
-        "@navikt/ds-css": "5.6.4",
+        "@navikt/ds-css": "5.9.2",
         "@navikt/ds-icons": "3.4.3",
-        "@navikt/ds-react": "5.6.4",
-        "@navikt/ds-tokens": "5.6.4",
+        "@navikt/ds-react": "5.9.2",
+        "@navikt/ds-tokens": "5.9.2",
         "@navikt/nav-dekoratoren-moduler": "2.1.3",
         "dayjs": "1.11.10",
-        "html-react-parser": "4.2.2",
+        "html-react-parser": "5.0.6",
         "js-cookie": "3.0.5",
-        "next": "13.5.4",
+        "next": "14.0.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
     },
     "devDependencies": {
-        "@types/js-cookie": "3.0.4",
-        "@types/node": "20.8.4",
-        "@types/react": "18.2.27",
-        "@types/react-dom": "18.2.12",
-        "eslint": "8.51.0",
-        "eslint-config-next": "13.5.4",
-        "eslint-plugin-css-modules": "2.11.4",
+        "@types/js-cookie": "3.0.5",
+        "@types/node": "20.8.10",
+        "@types/react": "18.2.36",
+        "@types/react-dom": "18.2.14",
+        "eslint": "8.53.0",
+        "eslint-config-next": "14.0.1",
+        "eslint-plugin-css-modules": "2.12.0",
         "prettier": "3.0.3",
-        "sass": "1.69.1",
-        "typescript": "5.1.6",
-        "typescript-plugin-css-modules": "5.0.1"
+        "sass": "1.69.5",
+        "typescript": "5.2.2",
+        "typescript-plugin-css-modules": "5.0.2"
     },
     "browserslist": {
         "production": [

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
         "react-dom": "18.2.0"
     },
     "devDependencies": {
-        "@types/js-cookie": "3.0.5",
-        "@types/node": "20.8.10",
+        "@types/js-cookie": "3.0.6",
+        "@types/node": "20.5.6",
         "@types/react": "18.2.36",
         "@types/react-dom": "18.2.14",
-        "eslint": "8.51.0",
+        "eslint": "8.52.0",
         "eslint-config-next": "14.0.1",
         "eslint-plugin-css-modules": "2.12.0",
         "prettier": "3.0.3",
         "sass": "1.69.5",
-        "typescript": "5.1.6",
+        "typescript": "5.2.2",
         "typescript-plugin-css-modules": "5.0.2"
     },
     "browserslist": {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
         "@types/node": "20.8.10",
         "@types/react": "18.2.36",
         "@types/react-dom": "18.2.14",
-        "eslint": "8.53.0",
+        "eslint": "8.51.0",
         "eslint-config-next": "14.0.1",
         "eslint-plugin-css-modules": "2.12.0",
         "prettier": "3.0.3",
         "sass": "1.69.5",
-        "typescript": "5.2.2",
+        "typescript": "5.1.6",
         "typescript-plugin-css-modules": "5.0.2"
     },
     "browserslist": {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Bump dependencies

## Testing

Har testet lokalt og i dev

## Dette trenger jeg å få et ekstra blikk på

Oppdatert til ny hovedversjon av html-react-parser, next, eslint-config-next.

Etter at bygget feilet først i dev, nedgraderte jeg eslint og typescript.  Bygget da ok.

Feilmeldingen i dev:
Error: Parsing error: DeprecationError: 'originalKeywordKind' has been deprecated since v5.0.0 and can no longer be used. Use 'identifierToKeywordKind(identifier)' instead.

For at den ikke skal feile, må ifølge Stackoverflow følgende gjøres:

Having updated libs:

@typescript-eslint/eslint-plugin
@typescript-eslint/parser
to versions 6.x resolved the problem.

Alternativt er å ikke oppgradere eslint og typescript som jeg gjorde.