### PR TITLE
fjern legacy-peer-deps i npm ci

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -55,7 +55,7 @@ jobs:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Build application


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- fjerner legacy-peer-deps i npm ci (npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.)
