### PR TITLE
Bump avhengigheter 040624

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
             "name": "navno-search-frontend",
             "version": "1.0.16-prod",
             "dependencies": {
-                "@navikt/aksel-icons": "6.7.1",
-                "@navikt/ds-css": "6.7.1",
-                "@navikt/ds-react": "6.7.1",
-                "@navikt/ds-tokens": "6.7.1",
+                "@navikt/aksel-icons": "6.10.0",
+                "@navikt/ds-css": "6.10.0",
+                "@navikt/ds-react": "6.10.0",
+                "@navikt/ds-tokens": "6.10.0",
                 "@navikt/nav-dekoratoren-moduler": "2.1.6",
                 "dayjs": "1.11.11",
                 "html-react-parser": "5.1.10",
@@ -22,14 +22,14 @@
             },
             "devDependencies": {
                 "@types/js-cookie": "3.0.6",
-                "@types/node": "20.12.10",
-                "@types/react": "18.3.1",
+                "@types/node": "20.14.1",
+                "@types/react": "18.3.3",
                 "@types/react-dom": "18.3.0",
                 "eslint": "8.57.0",
                 "eslint-config-next": "14.2.3",
                 "eslint-plugin-css-modules": "2.12.0",
-                "prettier": "3.2.5",
-                "sass": "1.77.0",
+                "prettier": "3.3.0",
+                "sass": "1.77.4",
                 "typescript": "5.4.5",
                 "typescript-plugin-css-modules": "5.1.0"
             }
@@ -253,27 +253,24 @@
             }
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "6.7.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.7.1/6c93069e7c03eba1ffe25634ad0188ddef34853b",
-            "integrity": "sha512-elwinBiLCrspiNIcmh/g2pT20/qJjc7ZRjoeXf5ntFl5pbDbsKe8u+CZz31K3jyhlQmlcTjUmIHtx9VTEgT20A==",
-            "license": "MIT"
+            "version": "6.10.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.10.0/d832911d79939b408fddfa1b4da7bac3527f6fe4",
+            "integrity": "sha512-MNjjpNc+wahqQBD4oSj/iIKJQCKZn5rGVh3RmKi95tX/Ta/MRskb807LTVZvq4S1+sOKK4VPgFONf8OertJz9g=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "6.7.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/6.7.1/339abde646df6131551b6e960df6e03faf152967",
-            "integrity": "sha512-Y0baI0jdy6cd6zgLhdF/eaBbTlLOue0mO6yEDP/hWDFoawWvAYw6FDxJdWp0ZUN8djG4VEqVlquvpoI5WtHqfA==",
-            "license": "MIT"
+            "version": "6.10.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/6.10.0/cd03b719d06e7993980699c2f6cb31795fa91535",
+            "integrity": "sha512-hpuoPzOVT23oDjZlq1NH9f8K9R/n/j3RhTJwiuT5lkpx8xkB/enZ7uc4A3eeyZszontxktZRTQN2KXNN0vhvBg=="
         },
         "node_modules/@navikt/ds-react": {
-            "version": "6.7.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/6.7.1/21374db1bf332e80b8724b2e23e59cfbf6610dd8",
-            "integrity": "sha512-pTHKQuBQGYjft72yM0n1YJ8BXOVU3Xy4Tx0klGQb+vlG9d1X2DXmDrvMO3W1u4/ZPUO7/8I8ufxCpNSJBI1XsA==",
-            "license": "MIT",
+            "version": "6.10.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/6.10.0/43abd526e58f1641effd0aa76a255a064068b5dd",
+            "integrity": "sha512-o+/MqUQMX++tp3mXe5Vlnu97CmDd+mdxcr8sT8jeLm9Jf3ms52O1hSdKK6NlJFYVBkOtZMH0Rr306n5n7X+VGA==",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
                 "@floating-ui/react-dom": "^2.0.9",
-                "@navikt/aksel-icons": "^6.7.1",
-                "@navikt/ds-tokens": "^6.7.1",
+                "@navikt/aksel-icons": "^6.10.0",
+                "@navikt/ds-tokens": "^6.10.0",
                 "clsx": "^2.1.0",
                 "date-fns": "^3.0.0",
                 "react-day-picker": "8.10.0"
@@ -284,10 +281,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "6.7.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/6.7.1/be99a17023a95d99199f904e9e631ae0f3518c4f",
-            "integrity": "sha512-eZ9lfhBP+S8WyphxhwthVkf0iXxavTESSJQm+o71SUA5QYOBlo23hWHIjSeVu5g7qrfxdJGW6O2TsUtXX0KdlQ==",
-            "license": "MIT"
+            "version": "6.10.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/6.10.0/56ae8412d9973f5a844b7a15d95c2ac3e008b171",
+            "integrity": "sha512-wnTS4mirTcTFoptobIp6PfmO8eEHDmt3FNxWAB+AORLOuwVF7Qrfb/zDnAEKBwN381ySSPuFZuQTudJU7hIcfQ=="
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
             "version": "2.1.6",
@@ -647,9 +643,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.12.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
-            "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+            "version": "20.14.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
+            "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -679,9 +675,9 @@
             "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
         },
         "node_modules/@types/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
+            "version": "18.3.3",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+            "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -4270,9 +4266,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+            "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -4506,6 +4502,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
@@ -4587,9 +4584,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sass": {
-            "version": "1.77.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.0.tgz",
-            "integrity": "sha512-eGj4HNfXqBWtSnvItNkn7B6icqH14i3CiCGbzMKs3BAPTq62pp9NBYsBgyN4cA+qssqo9r26lW4JSvlaUUWbgw==",
+            "version": "1.77.4",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.4.tgz",
+            "integrity": "sha512-vcF3Ckow6g939GMA4PeU7b2K/9FALXk2KF9J87txdHzXbUF9XRQRwSxcAs/fGaTnJeBFd7UoV22j3lzMLdM0Pw==",
             "devOptional": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
         "lint": "eslint src/"
     },
     "dependencies": {
-        "@navikt/ds-css": "6.7.1",
-        "@navikt/aksel-icons": "6.7.1",
-        "@navikt/ds-react": "6.7.1",
-        "@navikt/ds-tokens": "6.7.1",
+        "@navikt/ds-css": "6.10.0",
+        "@navikt/aksel-icons": "6.10.0",
+        "@navikt/ds-react": "6.10.0",
+        "@navikt/ds-tokens": "6.10.0",
         "@navikt/nav-dekoratoren-moduler": "2.1.6",
         "dayjs": "1.11.11",
         "html-react-parser": "5.1.10",
@@ -24,14 +24,14 @@
     },
     "devDependencies": {
         "@types/js-cookie": "3.0.6",
-        "@types/node": "20.12.10",
-        "@types/react": "18.3.1",
+        "@types/node": "20.14.1",
+        "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.3",
         "eslint-plugin-css-modules": "2.12.0",
-        "prettier": "3.2.5",
-        "sass": "1.77.0",
+        "prettier": "3.3.0",
+        "sass": "1.77.4",
         "typescript": "5.4.5",
         "typescript-plugin-css-modules": "5.1.0"
     },


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Oppdatert avhengigheter. Ingen større oppdateringer.

NB. Eslint må fortsatt stå på versjon 8.57.0, og oppdateres ikke til 9.4.0. (Mange warnings)

## Testing

Har testet selv i dev og lokalt