### PR TITLE
Legger til normalisering av context for innsending til dekoratøren

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -14,12 +14,30 @@ type Props = {
     Decorator: DecoratorComponents;
 };
 
+// Decorator will crash if invalid context ('privatperson', 'arbeidsgiver', 'samarbeidspartner') is passed.
+// Also, if context is an array, we will default to 'privatperson' as the header can only indicate one single context.
+const normalizeDecoratorContext = (context: string | string[]) => {
+    if (Array.isArray(context)) {
+        return 'privatperson';
+    }
+    if (
+        context !== 'privatperson' &&
+        context !== 'arbeidsgiver' &&
+        context !== 'samarbeidspartner'
+    ) {
+        return 'privatperson';
+    }
+    return context;
+};
+
 class MyDocument extends Document<Props> {
     static async getInitialProps(ctx: DocumentContext) {
         const initialProps = await Document.getInitialProps(ctx);
         const context = ctx.query?.f ?? 'privatperson';
-        const flatContext = Array.isArray(context) ? context[0] : context;
-        const Decorator = await getDecorator(flatContext);
+        const Decorator = await getDecorator(
+            normalizeDecoratorContext(context)
+        );
+
         return {
             ...initialProps,
             Decorator,

--- a/src/utils/fetch-decorator.tsx
+++ b/src/utils/fetch-decorator.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import Config from '../config';
 import {
     DecoratorEnvProps,
+    DecoratorParams,
     fetchDecoratorReact,
 } from '@navikt/nav-dekoratoren-moduler/ssr';
 
 const { DECORATOR_LOCAL_URL, ENV } = process.env;
+export type DecoratorContext = DecoratorParams['context'];
 
 const envMap: Record<typeof ENV, DecoratorEnvProps['env']> = {
     localhost: 'localhost',
@@ -27,7 +29,7 @@ const envProps =
               env: decoratorEnv,
           };
 
-export const getDecorator = async (context: any) => {
+export const getDecorator = async (context: DecoratorContext) => {
     const decoratorProps = {
         ...envProps,
         params: { ...Config.VARS.decoratorParams, context },


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Normaliserer innsending av context til dekoratøren fordi den krasjer om man sender inn noe annet enn "privatperson", "arbeidsgiver" eller "samarbeidspartner"

## Testing
Testes i dev
