### PR TITLE
Bump dependencies 250825

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@testing-library/react": "16.3.0",
                 "@testing-library/user-event": "14.6.1",
                 "@types/js-cookie": "3.0.6",
-                "@types/node": "24.3.0",
+                "@types/node": "22.15.23",
                 "@typescript-eslint/eslint-plugin": "8.40.0",
                 "@typescript-eslint/parser": "8.40.0",
                 "eslint": "8.57.1",
@@ -2619,13 +2619,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-            "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+            "version": "22.15.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.23.tgz",
+            "integrity": "sha512-7Ec1zaFPF4RJ0eXu1YT/xgiebqwqoJz8rYPDi/O2BcZ++Wpt0Kq9cl0eg6NN6bYbPnR67ZLo7St5Q3UK0SnARw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.10.0"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/prop-types": {
@@ -10022,9 +10022,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-            "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dependenciesComments": {
         "eslint": "Holdes på versjon 8.57.1. Nyeste versjon 9.34.0. From ESLint v9.0.0, the default configuration file is now eslint.config.js. ",
         "next": "Holdes på versjon 14.2.28. Nyeste versjon 15.5.0",
-        "eslint-config-next": "Holdes på versjon 14.2.28. Nyeste versjon 15.5.0"
+        "eslint-config-next": "Holdes på versjon 14.2.28. Nyeste versjon 15.5.0",
+        "@types/node": "Holdes på versjon 22.15.23. Nyeste versjon 24.3.0"
     },
     "dependencies": {
         "@navikt/aksel-icons": "7.28.1",
@@ -32,7 +33,7 @@
         "@testing-library/jest-dom": "6.8.0",
         "@testing-library/react": "16.3.0",
         "@testing-library/user-event": "14.6.1",
-        "@types/node": "24.3.0",
+        "@types/node": "22.15.23",
         "@typescript-eslint/eslint-plugin": "8.40.0",
         "@typescript-eslint/parser": "8.40.0",
         "@types/js-cookie": "3.0.6",


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Oppdatert avhengigheter i søkefrontenden

To major:

 jest: Gammel versjon 29.7.0. Nyeste versjon 30.0.3,
 jest-environment-jsdom:  Gammel versjon 29.7.0. Nyeste versjon 30.0.2.

## Testing

Har testet selv i dev

